### PR TITLE
更新、削除ボタンの表示調整

### DIFF
--- a/resources/js/Components/Markdown/MarkdownDetail/MarkdownDetail.tsx
+++ b/resources/js/Components/Markdown/MarkdownDetail/MarkdownDetail.tsx
@@ -16,15 +16,18 @@ import 'react-toastify/dist/ReactToastify.css';
 
 interface MarkdownDetail {
     post: MarkdownPost;
+    loginUserId: number;
 }
 
 /**
  * マークダウン詳細ページ
  * @param post MarkdownPost
+ * @param loginUserId number
  * @returns JSX
  */
 const MarkdownDetail = ({
     post,
+    loginUserId,
 }: MarkdownDetail) => {
     const [isImageLoading, setIsImageLoading] = useState(true);
     const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -93,6 +96,8 @@ const MarkdownDetail = ({
                     <div className="flex flex-end">
                         <MdDetailButtonArea
                             postId={post.id}
+                            loginUserId={loginUserId}
+                            postUserId={post.user_id}
                             handleDelete={handleDelete}
                         />
                     </div>

--- a/resources/js/Components/Markdown/MarkdownDetail/molecules/MdDetailButtonArea.tsx
+++ b/resources/js/Components/Markdown/MarkdownDetail/molecules/MdDetailButtonArea.tsx
@@ -3,17 +3,23 @@ import MarkdownLinkButton from '@/Components/Markdown/atoms/button/MarkdownLinkB
 
 interface MdDetailButtonAreaProps {
     postId: string;
+    loginUserId: number;
+    postUserId: number;
     handleDelete: (id: string) => void;
 };
 
 /**
  * [MarkdownDetail] ボタンエリアコンポーネント
  * @param postId
+ * @param loginUserId
+ * @param postUserId
  * @param handleDelete
  * @returns JSX
  */
 const MdDetailButtonArea = ({
     postId,
+    loginUserId,
+    postUserId,
     handleDelete,
 }: MdDetailButtonAreaProps) => {
     return (
@@ -23,19 +29,24 @@ const MdDetailButtonArea = ({
                 href="/markdown"
                 additionalClasses="mr-2 bg-amber-500 text-white hover:bg-amber-600 focus:ring-amber-500"
             />
-            <MarkdownLinkButton
-                label="Update"
-                href={`/markdown/editor/${postId}`}
-                additionalClasses="mr-2 bg-amber-600 text-white hover:bg-amber-700 focus:ring-amber-600"
-            />
-            
-            <Button
-                onClick={() => handleDelete(postId)}
-                className="bg-amber-700 text-white px-4 py-2 rounded-md shadow-md hover:bg-amber-800 transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-amber-700 focus:ring-opacity-50">
-                Delete
-            </Button>
+
+            {loginUserId === postUserId && (
+                <>
+                    <MarkdownLinkButton
+                        label="Update"
+                        href={`/markdown/editor/${postId}`}
+                        additionalClasses="mr-2 bg-amber-600 text-white hover:bg-amber-700 focus:ring-amber-600"
+                    />
+                    
+                    <Button
+                        onClick={() => handleDelete(postId)}
+                        className="bg-amber-700 text-white px-4 py-2 rounded-md shadow-md hover:bg-amber-800 transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-amber-700 focus:ring-opacity-50">
+                        Delete
+                    </Button>
+                </>
+            )}
         </>
     )
 }
 
-export default MdDetailButtonArea
+export default MdDetailButtonArea;

--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -5,10 +5,7 @@ import NavLink from '@/Components/NavLink';
 import ResponsiveNavLink from '@/Components/ResponsiveNavLink';
 import { Link, usePage } from '@inertiajs/react';
 import { PageProps, User } from '@/types';
-
-interface InertiaPage<T> {
-    props: T;
-}
+import { InertiaPage } from '@/types/type-pages';
 
 export default function Authenticated({ 
     header, 

--- a/resources/js/Pages/Markdown/MarkdownDetailPage.tsx
+++ b/resources/js/Pages/Markdown/MarkdownDetailPage.tsx
@@ -1,8 +1,10 @@
 import { ReactElement } from 'react';
-import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import MarkdownLayout from '@/Layouts/MarkdownLayout';
 import { PageProps } from '@/types';
 import { MarkdownPost } from '@/types/types';
+import { InertiaPage } from '@/types/type-pages';
+import { usePage } from '@inertiajs/react';
+import MarkdownLayout from '@/Layouts/MarkdownLayout';
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import MarkdownDetail from '@/Components/Markdown/MarkdownDetail/MarkdownDetail';
 
 /**
@@ -20,9 +22,16 @@ interface MarkdownDetailPageProps extends PageProps {
 function MarkdownDetailsPage({
     post,
 }: MarkdownDetailPageProps) {
+  const { props: page }: InertiaPage<PageProps> = usePage();
+  const user = page.auth.user;
+  //user.
+  
   return (
     <>
-        <MarkdownDetail post={post} />
+        <MarkdownDetail 
+          post={post} 
+          loginUserId={user.id}
+        />
     </>
   );
 }

--- a/resources/js/__tests__/Components/Markdown/MarkdownDetail/molecules/MdDetailButtonArea.test.tsx
+++ b/resources/js/__tests__/Components/Markdown/MarkdownDetail/molecules/MdDetailButtonArea.test.tsx
@@ -5,7 +5,12 @@ describe('MdDetailButtonArea', () => {
     const mockHandleDelete = vi.fn();
 
     beforeEach(() => {
-        render(<MdDetailButtonArea postId="123" handleDelete={mockHandleDelete} />);
+        render(<MdDetailButtonArea 
+            postId="123" 
+            loginUserId={1}
+            postUserId={1}
+            handleDelete={mockHandleDelete} 
+        />);
     });
 
     afterEach(() => {
@@ -33,5 +38,32 @@ describe('MdDetailButtonArea', () => {
         const deleteButton = screen.getByText('Delete');
         fireEvent.click(deleteButton);
         expect(mockHandleDelete).toHaveBeenCalledWith('123');
+    });
+});
+
+describe('MdDetailButtonArea - other user', () => {
+    const mockHandleDelete = vi.fn();
+
+    beforeEach(() => {
+        render(<MdDetailButtonArea 
+            postId="123" 
+            loginUserId={2}
+            postUserId={1}
+            handleDelete={mockHandleDelete} 
+        />);
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('update button rendering test', () => {
+        const updateButton = screen.queryByText('Update');
+        expect(updateButton).toBeNull();
+    });
+
+    it('delete button rendering test', () => {
+        const deleteButton = screen.queryByText('Delete');
+        expect(deleteButton).toBeNull();
     });
 });

--- a/resources/js/types/type-pages.ts
+++ b/resources/js/types/type-pages.ts
@@ -1,0 +1,4 @@
+
+export interface InertiaPage<T> {
+    props: T;
+}


### PR DESCRIPTION
以下対応しました。
[対応前]
現在全ユーザーが更新、削除可能。

[対応後]
投稿したユーザーが更新、削除可能とする。

updateボタン、削除ボタンの表示/非表示を調整。
